### PR TITLE
Windows: Handle different Cygwin values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ ifeq ($(UNAME),CYGWIN_NT-10.0)
 endif
 
 install:
+	echo UNAME: $(UNAME)
+	echo PLATFORM: $(PLATFORM)
 	mkdir -p $(cur__bin)
 	cp -r bin/esy-installer $(cur__bin)/esy-installer
 	cp -r vendor-$(PLATFORM)/bin/* $(cur__bin)/opam-installer

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install
 
-PLATFORM := unknown
+PLATFORM := cygwinNT10
 
 UNAME := $(shell uname -s)
 ifeq ($(UNAME),Linux)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install
 
-PLATFORM := cygwinNT10
+PLATFORM := unknown
 
 UNAME := $(shell uname -s)
 ifeq ($(UNAME),Linux)
@@ -9,13 +9,11 @@ endif
 ifeq ($(UNAME),Darwin)
 	PLATFORM := darwin
 endif
-ifeq ($(UNAME),CYGWIN_NT-10.0)
+ifneq (,$(findstring CYGWIN,$(UNAME)))
 	PLATFORM := cygwinNT10
 endif
 
 install:
-	echo UNAME: $(UNAME)
-	echo PLATFORM: $(PLATFORM)
 	mkdir -p $(cur__bin)
 	cp -r bin/esy-installer $(cur__bin)/esy-installer
 	cp -r vendor-$(PLATFORM)/bin/* $(cur__bin)/opam-installer


### PR DESCRIPTION
In the AppVeyor build environment, we'd get errors with the `esy-installer` package of the form:
```
esy: error, exiting...
     build failed
       Building @esy-ocaml/esy-installer@0.0.0
       Build log:
         # esy-build-package: building: @esy-ocaml/esy-installer@0.0.0
         # esy-build-package: running: "make" "install"
         mkdir -p
     C:/Users/appveyor/.esy/3_/s/esy_ocaml__slash__esy_installer-0.0.0-99040cc2/bin
         cp -r bin/esy-installer
     C:/Users/appveyor/.esy/3_/s/esy_ocaml__slash__esy_installer-0.0.0-99040cc2/bin/esy-installer
         cp -r vendor-unknown/bin/*
     C:/Users/appveyor/.esy/3_/s/esy_ocaml__slash__esy_installer-0.0.0-99040cc2/bin/opam-installer
         cp: cannot stat 'vendor-unknown/bin/*': No such file or directory
         make: *** [Makefile:19: install] Error 1
         esy-build-package: 
                            command failed:
                            "make" "install"
         
Command exited with code 1
```

In some of those environments, `uname -S` would return another version of cygwin, like `CYGWIN_NT-6.3` instead of `CYGWIN_NT-10.0` like we expected in the `Makefile`.

This fix loosens up that restriction, and just checks to see if `CYGWIN` is present - if so, we'll use the cygwin strategy.